### PR TITLE
Introduce WSDL CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,80 @@ $loader = new FlatteningLoader(new StreamWrapperLoader());
 $contents = $loader($wsdl);
 ```
 
+### CallbackLoader
+
+This loader can be used if you want to have more control about how to load a WSDL.
+It can be used to decorate another loader, add debug statements, apply custom loading logic, ...
+
+```php
+use Soap\Wsdl\Loader\CallbackLoader;
+
+$loader = new CallbackLoader(static function (string $location) use ($loader, $style): string {
+    $style->write('> Loading '.$location . '...');
+
+    $result =  $loader($location);
+    $style->writeln(' DONE!');
+
+    return $result;
+})
+
+$contents = $loader($wsdl);
+```
+
+## WSDL CLI Tools
+
+```
+wsdl-tools 1.0.0
+
+Available commands:
+  completion  Dump the shell completion script
+  flatten     Flatten a remote or local WSDL file into 1 file that contains all includes.
+  help        Display help for a command
+  list        List commands
+  validate    Run validations a (flattened) WSDL file.
+```
+
+### Flattening
+
+```
+./bin/wsdl flatten 'https://your/?wsdl' out.wsdl
+```
+
+This command will download the provided WSDL location.
+If any imports are detected, it will download these as well.
+The final result is stored in a single WSDL file.
+
+### Validating
+
+```
+./bin/wsdl validate out.wsdl
+```
+
+This command performs some basic validations on the provided WSDL file.
+If your WSDL contains any imports, you'll have to flatten the WSDL into a single file first.
+
+### Custom WSDL Loader
+
+By default, all CLI tools use the StreamWrapperLoader.
+All CLI tools have a `--loader=file.php` option that can be used to apply a custom WSDL loader.
+This can be handy if your WSDL is located behind authentication or if you want to get control over the HTTP level.
+
+Example custom PHP loader:
+
+```php
+<?php
+
+use Soap\Wsdl\Loader\StreamWrapperLoader;
+
+return new StreamWrapperLoader(
+    stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header'=> sprintf('Authorization: Basic %s', base64_encode('username:password')),
+        ],        
+    ])
+);
+```
 
 ## WSDL Validators
 

--- a/bin/wsdl
+++ b/bin/wsdl
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Soap\Wsdl\Console\AppFactory;
+
+(function () {
+    $loaded = array_reduce(
+        [
+            __DIR__.'/../vendor/autoload.php', // Used when executed in this package's SRC
+            __DIR__.'/../../../autoload.php' // Used when executed in vendor/bin of your project
+        ],
+        static function (?string $loaded, string $file): ?string {
+            if ( ! $loaded && is_file($file)) {
+                require_once($file);
+
+                return $file;
+            }
+
+            return $loaded;
+        }
+    );
+
+    if (!$loaded) {
+        fwrite(
+            STDERR,
+            'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+            'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+            'php composer.phar install'.PHP_EOL
+        );
+        exit(1);
+    }
+
+    $app = AppFactory::create();
+    $app->run();
+})();

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,12 @@
             "email": "toonverwerft@gmail.com"
         }
     ],
+    "bin": [
+        "bin/wsdl"
+    ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^8.0",
         "ext-dom": "*",
@@ -26,9 +32,11 @@
         "league/uri": "^6.5",
         "league/uri-components": "^2.4",
         "php-soap/xml": "^1.2",
+        "symfony/console": "^5.4|^6.0",
         "veewee/xml": "~1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "psalm/plugin-symfony": "^3.1"
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,14 +14,17 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
-            <directory name="tests" />
+            <directory name="vendor"/>
+            <directory name="tests"/>
         </ignoreFiles>
     </projectFiles>
     <ignoreExceptions>
-        <class name="InvalidArgumentException" />
-        <class name="Psl\Exception\InvariantViolationException" />
+        <class name="InvalidArgumentException"/>
+        <class name="Psl\Exception\InvariantViolationException"/>
     </ignoreExceptions>
+    <plugins>
+        <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/src/Console/AppFactory.php
+++ b/src/Console/AppFactory.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Wsdl\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\LogicException;
+
+final class AppFactory
+{
+    /**
+     * @throws LogicException
+     */
+    public static function create(): Application
+    {
+        $app = new Application('wsdl-tools', '1.0.0');
+        $app->addCommands([
+            new Command\FlattenCommand(),
+            new Command\ValidateCommand(),
+        ]);
+
+        return $app;
+    }
+}

--- a/src/Console/Command/FlattenCommand.php
+++ b/src/Console/Command/FlattenCommand.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Wsdl\Console\Command;
+
+use Exception;
+use Psl\Filesystem;
+use Soap\Wsdl\Console\Helper\ConfiguredLoader;
+use Soap\Wsdl\Loader\CallbackLoader;
+use Soap\Wsdl\Loader\FlatteningLoader;
+use Soap\Wsdl\Loader\WsdlLoader;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class FlattenCommand extends Command
+{
+    public static function getDefaultName(): string
+    {
+        return 'flatten';
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Flatten a remote or local WSDL file into 1 file that contains all includes.');
+        $this->addArgument('wsdl', InputArgument::REQUIRED, 'Provide the URI of the WSDL you want to flatten');
+        $this->addArgument('output', InputArgument::REQUIRED, 'Define where the file must be written to');
+        $this->addOption('loader', 'l', InputOption::VALUE_REQUIRED, 'Customize the WSDL loader file that will be used');
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+        $loader = ConfiguredLoader::createFromConfig(
+            $input->getOption('loader'),
+            fn (WsdlLoader $loader) => $this->configureLoader($loader, $style)
+        );
+        $wsdl = $input->getArgument('wsdl');
+        $output = $input->getArgument('output');
+
+        $style->info('Flattening WSDL "'.$wsdl.'"');
+        $style->warning('This can take a while...');
+        $contents = $loader($wsdl);
+
+        $style->info('Downloaded the WSDL. Writing it to "'.$output.'".');
+
+        Filesystem\write_file($output, $contents);
+
+        $style->success('Succesfully flattened your WSDL!');
+
+        return self::SUCCESS;
+    }
+
+    private function configureLoader(WsdlLoader $loader, SymfonyStyle $style): WsdlLoader
+    {
+        return new FlatteningLoader(
+            new CallbackLoader(static function (string $location) use ($loader, $style): string {
+                $style->write('> Loading '.$location . '...');
+
+                $result =  $loader($location);
+                $style->writeln(' DONE!');
+
+                return $result;
+            })
+        );
+    }
+}

--- a/src/Console/Command/ValidateCommand.php
+++ b/src/Console/Command/ValidateCommand.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Wsdl\Console\Command;
+
+use Exception;
+use Soap\Wsdl\Console\Helper\ConfiguredLoader;
+use Soap\Wsdl\Xml\Validator;
+use Soap\Xml\Xpath\WsdlPreset;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use VeeWee\Xml\Dom\Document;
+use VeeWee\Xml\ErrorHandling\Issue\IssueCollection;
+
+final class ValidateCommand extends Command
+{
+    public static function getDefaultName(): string
+    {
+        return 'validate';
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Run validations a (flattened) WSDL file.');
+        $this->addArgument('wsdl', InputArgument::REQUIRED, 'Provide the URI of the WSDL you want to validate');
+        $this->addOption('loader', 'l', InputOption::VALUE_REQUIRED, 'Customize the WSDL loader file that will be used');
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+        $loader = ConfiguredLoader::createFromConfig($input->getOption('loader'));
+        $wsdl = $input->getArgument('wsdl');
+
+        $style->info('Loading "'.$wsdl.'"...');
+        $document = Document::fromXmlString($loader($wsdl));
+        $xpath = $document->xpath(new WsdlPreset($document));
+
+        $result = $this->runValidationStage(
+            $style,
+            'Validating WSDL syntax',
+            static fn () => $document->validate(new Validator\WsdlSyntaxValidator())
+        );
+
+        $result = $result && $this->runValidationStage(
+            $style,
+            'Validating XSD types...',
+            static function () use ($style, $document, $xpath): ?IssueCollection {
+                $schemas = $xpath->query('//schema:schema');
+                if ($schemas->count() !== 1) {
+                    $style->warning('Skipped : XSD types can only be validated if there is one schema element.');
+                    return null;
+                }
+
+                return $document->validate(new Validator\SchemaSyntaxValidator());
+            }
+        );
+
+        return $result ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param callable(): ?IssueCollection $validator
+     */
+    private function runValidationStage(SymfonyStyle $style, string $label, callable $validator): bool
+    {
+        $style->info($label.'...');
+        $issues = $validator();
+
+        // Skipped ...
+        if ($issues === null) {
+            return true;
+        }
+
+        if ($issues->count()) {
+            $style->block($issues->toString());
+            $style->error('Validation failed!');
+            return false;
+        }
+
+        $style->success('All good!');
+        return true;
+    }
+}

--- a/src/Console/Helper/ConfiguredLoader.php
+++ b/src/Console/Helper/ConfiguredLoader.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Wsdl\Console\Helper;
+
+use Psl\Filesystem;
+use Psl\Type\Exception\AssertException;
+use Soap\Wsdl\Loader\StreamWrapperLoader;
+use Soap\Wsdl\Loader\WsdlLoader;
+use function Psl\invariant;
+use function Psl\Type\object;
+
+final class ConfiguredLoader
+{
+    /**
+     * @param (callable(WsdlLoader): WsdlLoader)|null $configurator
+     *
+     * @throws AssertException
+     *
+     * @psalm-suppress UnresolvableInclude - Including dynamic includes is acutally the goal :)
+     */
+    public static function createFromConfig(?string $file, callable $configurator = null): WsdlLoader
+    {
+        $loader = new StreamWrapperLoader();
+
+        if ($file) {
+            invariant(Filesystem\exists($file), 'File "%s" does not exist.', $file);
+            invariant(Filesystem\is_file($file), 'File "%s" is not a file.', $file);
+            invariant(Filesystem\is_readable($file), 'File "%s" is not readable.', $file);
+
+            /** @var WsdlLoader $included */
+            $included = require $file;
+
+            $loader = object(WsdlLoader::class)->assert($included);
+        }
+
+        return $configurator ? $configurator($loader) : $loader;
+    }
+}

--- a/src/Loader/CallbackLoader.php
+++ b/src/Loader/CallbackLoader.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Wsdl\Loader;
+
+use Exception;
+use Soap\Wsdl\Exception\UnloadableWsdlException;
+
+final class CallbackLoader implements WsdlLoader
+{
+    /**
+     * @param callable(string): string $callback
+     */
+    private $callback;
+
+    /**
+     * @param callable(string): string $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @throws UnloadableWsdlException
+     */
+    public function __invoke(string $location): string
+    {
+        try {
+            return ($this->callback)($location);
+        } catch (UnloadableWsdlException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            throw UnloadableWsdlException::fromException($e);
+        }
+    }
+}

--- a/tests/Unit/Console/Helper/ConfiguredLoaderTest.php
+++ b/tests/Unit/Console/Helper/ConfiguredLoaderTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace SoapTest\Wsdl\Unit\Console\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Soap\Wsdl\Console\Helper\ConfiguredLoader;
+use Soap\Wsdl\Loader\CallbackLoader;
+use Soap\Wsdl\Loader\StreamWrapperLoader;
+use function Psl\Filesystem\delete_file;
+use function Psl\Filesystem\write_file;
+
+final class ConfiguredLoaderTest extends TestCase
+{
+    public function test_it_can_load_without_file(): void
+    {
+        $loader = ConfiguredLoader::createFromConfig(null);
+        static::assertInstanceOf(StreamWrapperLoader::class, $loader);
+    }
+
+    public function test_it_can_configure_loader(): void
+    {
+        $loader = ConfiguredLoader::createFromConfig(
+            null,
+            static function ($internal) {
+                self::assertInstanceOf(StreamWrapperLoader::class, $internal);
+
+                return new CallbackLoader(static fn () => '');
+            }
+        );
+        static::assertInstanceOf(CallbackLoader::class, $loader);
+    }
+
+    
+    public function test_it_can_load_from_file(): void
+    {
+        $this->withLoaderFile(
+            static function (string $file) {
+                $loader = ConfiguredLoader::createFromConfig($file);
+                self::assertSame('loaded', $loader('x'));
+            }
+        );
+    }
+
+    
+    public function test_it_can_configure_loaded_from_file(): void
+    {
+        $this->withLoaderFile(
+            static function (string $file) {
+                $loader = ConfiguredLoader::createFromConfig($file, static function ($internal) {
+                    self::assertInstanceOf(CallbackLoader::class, $internal);
+
+                    return new CallbackLoader(static fn () => 'overwritten');
+                });
+                self::assertSame('overwritten', $loader('x'));
+            },
+        );
+    }
+
+    private function withLoaderFile(callable $execute): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'wsdlloader');
+        write_file(
+            $file,
+            <<<EOPHP
+        <?php
+        return new \Soap\Wsdl\Loader\CallbackLoader(static fn () => 'loaded');    
+        EOPHP
+        );
+
+        try {
+            $execute($file);
+        } finally {
+            delete_file($file);
+        }
+    }
+}

--- a/tests/Unit/Loader/CallbackLoaderTest.php
+++ b/tests/Unit/Loader/CallbackLoaderTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace SoapTest\Wsdl\Unit\Loader;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Soap\Wsdl\Exception\UnloadableWsdlException;
+use Soap\Wsdl\Loader\CallbackLoader;
+
+final class CallbackLoaderTest extends TestCase
+{
+    public function test_it_can_load_wsdl_through_callback(): void
+    {
+        $loader = new CallbackLoader(static fn (string $wsdl): string => $wsdl);
+        $contents = ($loader)('wsdl');
+
+        static::assertSame('wsdl', $contents);
+    }
+
+    public function test_it_transforms_exceptions(): void
+    {
+        $loader = new CallbackLoader(static fn (string $wsdl): string => throw new Exception('hello'));
+
+        $this->expectException(UnloadableWsdlException::class);
+        $this->expectExceptionMessage('hello');
+        ($loader)('wsdl');
+    }
+
+    public function test_it_does_not_transforms_unloadable_exception(): void
+    {
+        $loader = new CallbackLoader(
+            static fn (string $wsdl): string => throw UnloadableWsdlException::fromLocation($wsdl)
+        );
+
+        $this->expectException(UnloadableWsdlException::class);
+        $this->expectExceptionMessage('file.wsdl');
+        ($loader)('file.wsdl');
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Introduces a new set of CLI tools for working with WSDLs.
For now:

* Flatten remote or local WSDL files.
* Validate WSDL file syntax based on included XSD files

```
wsdl-tools 1.0.0

Available commands:
  completion  Dump the shell completion script
  flatten     Flatten a remote or local WSDL file into 1 file that contains all includes.
  help        Display help for a command
  list        List commands
  validate    Run validations a (flattened) WSDL file.
```


![Screenshot 2022-01-28 at 10 58 56](https://user-images.githubusercontent.com/1618158/151526832-5c5f77c0-312f-4a0c-93d5-aca03d4982f6.png)
![Screenshot 2022-01-28 at 10 59 29](https://user-images.githubusercontent.com/1618158/151526836-161d8910-0713-43ee-a3f1-8f1b434b4e3b.png)

