### PR TITLE
Fix import of removed (optimized) root xmlns during flattening schemas

### DIFF
--- a/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
+++ b/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
@@ -8,6 +8,7 @@ use Soap\Wsdl\Loader\Context\FlatteningContext;
 use Soap\Wsdl\Loader\StreamWrapperLoader;
 use Soap\Wsdl\Xml\Configurator\FlattenXsdImports;
 use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Configurator\canonicalize;
 use function VeeWee\Xml\Dom\Configurator\comparable;
 
 final class FlattenXsdImportsTest extends TestCase
@@ -16,47 +17,59 @@ final class FlattenXsdImportsTest extends TestCase
      *
      * @dataProvider provideTestCases
      */
-    public function test_it_can_flatten_xsd_imports(string $wsdlUri, Document $expected): void
+    public function test_it_can_flatten_xsd_imports(string $wsdlUri, Document $expected, callable $xmlConfigurator): void
     {
         $wsdl = Document::fromXmlFile($wsdlUri);
         $configurator = new FlattenXsdImports(
             $wsdlUri,
             FlatteningContext::forWsdl($wsdlUri, $wsdl, new StreamWrapperLoader())
         );
-        $flattened = Document::fromUnsafeDocument($wsdl->toUnsafeDocument(), $configurator, comparable());
+        $flattened = Document::fromUnsafeDocument($wsdl->toUnsafeDocument(), $configurator, $xmlConfigurator);
 
-        static::assertSame($expected->toXmlString(), $flattened->toXmlString());
+        static::assertSame($expected->reconfigure($xmlConfigurator)->toXmlString(), $flattened->toXmlString());
     }
 
     public function provideTestCases()
     {
         yield 'single-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/single-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/single-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/single-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'once-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/once-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/once-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/once-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'multi-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/multi-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/multi-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/multi-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'circular-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/circular-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/circular-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/circular-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'redefine-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/redefine-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/redefine-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/redefine-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'tnsless-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/tnsless-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/tnsless-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/tnsless-xsd-result.wsdl'),
+            comparable(),
         ];
         yield 'grouped-xsd' => [
             'wsdl' => FIXTURE_DIR.'/flattening/grouped-xsd.wsdl',
-            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/grouped-xsd-result.wsdl', comparable()),
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/grouped-xsd-result.wsdl'),
+            comparable(),
+        ];
+        yield 'root-xmlns-import-issue' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/root-xmlns-import-issue.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/root-xmlns-import-issue-result.wsdl'),
+            canonicalize(),
         ];
     }
 }

--- a/tests/fixtures/flattening/result/root-xmlns-import-issue-result.wsdl
+++ b/tests/fixtures/flattening/result/root-xmlns-import-issue-result.wsdl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions
+        name="agenzia"
+        targetNamespace="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle"
+      xmlns:imw="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle"
+      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+      xmlns:core="http://www.immobinet.it/schema/WebserviceCoreBundle"
+      xmlns:imm2="http://www.immobinet.it/schema/WebserviceImmobileBundle"
+>
+    <wsdl:types>
+        <xsd:schema xmlns:imsw="http://www.immobinet.it/schema/WebserviceModAgenziaBundle" elementFormDefault="qualified" targetNamespace="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle">
+            <xsd:import namespace="http://www.immobinet.it/schema/WebserviceCoreBundle"/>
+        </xsd:schema>
+        <xsd:schema
+            xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:imm="http://www.immobinet.it/schema/WebserviceCoreBundle"
+            targetNamespace="http://www.immobinet.it/schema/WebserviceCoreBundle"
+            elementFormDefault="qualified"
+        >
+	        <xsd:complexType name="Auth">
+		        <xsd:sequence>
+ 			        <xsd:element name="username" type="string" maxOccurs="1" minOccurs="1"/>
+			        <xsd:element name="password" type="string" maxOccurs="1" minOccurs="1"/>
+		        </xsd:sequence>
+	        </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+</wsdl:definitions>

--- a/tests/fixtures/flattening/root-xmlns-import-issue.wsdl
+++ b/tests/fixtures/flattening/root-xmlns-import-issue.wsdl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions name="agenzia" targetNamespace="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle"
+                  xmlns:imw="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:core="http://www.immobinet.it/schema/WebserviceCoreBundle"
+                  xmlns:imm2="http://www.immobinet.it/schema/WebserviceImmobileBundle">
+    <wsdl:types>
+        <xsd:schema elementFormDefault="qualified"
+                    targetNamespace="http://www.immobinet.it/wsdl/WebserviceModAgenziaBundle"
+                    xmlns:imsw="http://www.immobinet.it/schema/WebserviceModAgenziaBundle"
+        >
+            <xsd:import schemaLocation="xsd/root-xmlns-import-issue-core.xsd"
+                        namespace="http://www.immobinet.it/schema/WebserviceCoreBundle"></xsd:import>
+
+        </xsd:schema>
+    </wsdl:types>
+</wsdl:definitions>

--- a/tests/fixtures/flattening/xsd/root-xmlns-import-issue-core.xsd
+++ b/tests/fixtures/flattening/xsd/root-xmlns-import-issue-core.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.immobinet.it/schema/WebserviceCoreBundle"
+        xmlns:imm="http://www.immobinet.it/schema/WebserviceCoreBundle" elementFormDefault="qualified">
+    <complexType name="Auth">
+        <sequence>
+            <element name="username" type="string" maxOccurs="1" minOccurs="1"></element>
+            <element name="password" type="string" maxOccurs="1" minOccurs="1"></element>
+        </sequence>
+    </complexType>
+</schema>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #15

#### Summary

Fixes #15.

This PR fixes an ext-dom related PHP issue in which the root XMLNS get optimized (removed) out of the imported XSD schema element.

See more details in this gist: https://gist.github.com/veewee/32c3aa94adcf878700a9d5baa4b2a2de

