### PR TITLE
Make it possible for wsdl:import tags to directly import XSD items.

### DIFF
--- a/src/Loader/StreamWrapperLoader.php
+++ b/src/Loader/StreamWrapperLoader.php
@@ -22,11 +22,11 @@ final class StreamWrapperLoader implements WsdlLoader
     {
         $this->context = $context;
     }
-    
+
     public function __invoke(string $location): string
     {
         try {
-            $content = file_get_contents(
+            $content = @file_get_contents(
                 $location,
                 context: is_resource($this->context) ? $this->context : null
             );

--- a/src/Xml/Configurator/FlattenWsdlImports.php
+++ b/src/Xml/Configurator/FlattenWsdlImports.php
@@ -9,12 +9,14 @@ use DOMElement;
 use Soap\Wsdl\Exception\UnloadableWsdlException;
 use Soap\Wsdl\Loader\Context\FlatteningContext;
 use Soap\Wsdl\Uri\IncludePathBuilder;
+use Soap\Xml\Xmlns;
 use Soap\Xml\Xpath\WsdlPreset;
 use VeeWee\Xml\Dom\Configurator\Configurator;
 use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Exception\RuntimeException;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Locator\Node\children;
+use function VeeWee\Xml\Dom\Manipulator\Node\append_external_node;
 use function VeeWee\Xml\Dom\Manipulator\Node\remove;
 use function VeeWee\Xml\Dom\Manipulator\Node\replace_by_external_nodes;
 
@@ -66,11 +68,34 @@ final class FlattenWsdlImports implements Configurator
         }
 
         $imported = Document::fromXmlString($result);
-        $definitions = $imported->map(document_element());
+
+        // A wsdl:import can be either a WSDL or an XSD file:
+        match ($imported->locateDocumentElement()->namespaceURI) {
+            Xmlns::xsd()->value() => $this->importXsdPart($import, $imported),
+            default => $this->importWsdlPart($import, $imported),
+        };
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function importWsdlPart(DOMElement $importElement, Document $importedDocument): void
+    {
+        $definitions = $importedDocument->map(document_element());
 
         replace_by_external_nodes(
-            $import,
+            $importElement,
             children($definitions)
         );
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function importXsdPart(DOMElement $importElement, Document $importedDocument): void
+    {
+        $types = $this->context->types();
+        remove($importElement);
+        append_external_node($types, $importedDocument->locateDocumentElement());
     }
 }

--- a/tests/Unit/Xml/Configurator/FlattenWsdlImportsTest.php
+++ b/tests/Unit/Xml/Configurator/FlattenWsdlImportsTest.php
@@ -46,5 +46,13 @@ final class FlattenWsdlImportsTest extends TestCase
             'wsdl' => FIXTURE_DIR.'/flattening/multi-import.wsdl',
             'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/multi-import-result.wsdl', comparable()),
         ];
+        yield 'xsd-imports' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/import-xsd.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/import-xsd-result.wsdl', comparable()),
+        ];
+        yield 'multi-xsd-imports' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/import-multi-xsd.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/import-multi-xsd-result.wsdl', comparable()),
+        ];
     }
 }

--- a/tests/fixtures/flattening/import-multi-xsd.wsdl
+++ b/tests/fixtures/flattening/import-multi-xsd.wsdl
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        targetNamespace="http://soapinterop.org/">
+    <import namespace="http://soapinterop.org/store1" location="xsd/store1.xsd" />
+    <import namespace="http://soapinterop.org/store2" location="xsd/store2.xsd" />
+</definitions>

--- a/tests/fixtures/flattening/import-xsd.wsdl
+++ b/tests/fixtures/flattening/import-xsd.wsdl
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        targetNamespace="http://soapinterop.org/">
+    <import namespace="http://soapinterop.org/store1" location="xsd/store1.xsd" />
+</definitions>

--- a/tests/fixtures/flattening/result/import-multi-xsd-result.wsdl
+++ b/tests/fixtures/flattening/result/import-multi-xsd-result.wsdl
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+            <xsd:complexType name="Store">
+                <xsd:sequence>
+                    <element minOccurs="1" maxOccurs="1" name="Attribute1" type="string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+        </schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store2">
+            <xsd:complexType name="Store">
+                <xsd:sequence>
+                    <element minOccurs="1" maxOccurs="1" name="Attribute2" type="string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+        </schema>
+    </types>
+</definitions>

--- a/tests/fixtures/flattening/result/import-xsd-result.wsdl
+++ b/tests/fixtures/flattening/result/import-xsd-result.wsdl
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+            <xsd:complexType name="Store">
+                <xsd:sequence>
+                    <element minOccurs="1" maxOccurs="1" name="Attribute1" type="string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+        </schema>
+    </types>
+</definitions>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #19

#### Summary

Fixes #19



```xml
<definitions 
	xmlns="http://schemas.xmlsoap.org/wsdl/" 
	...>
	<import location="AXLSoap.xsd" namespace="http://www.cisco.com/AXL/API/15.0"/>
</definitiions>	
```

#### Current behaviour


The flattening process results in:

```xml
<definitions 
	xmlns="http://schemas.xmlsoap.org/wsdl/" 
	...>

	XSD CONTENT

        <types/>
</definitiions>	
```


#### Expected behaviour

```xml
<definitions 
	xmlns="http://schemas.xmlsoap.org/wsdl/" 
	...>
        <types>
         	XSD CONTENT
        </types>
</definitiions>	
```

This pull requests makes sure to import the full XSD `<schema />` in the `<types />` element.



