### PR TITLE
Make sure import tags are positioned as first elements inside the schema.

### DIFF
--- a/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
+++ b/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
@@ -71,5 +71,10 @@ final class FlattenXsdImportsTest extends TestCase
             'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/root-xmlns-import-issue-result.wsdl'),
             canonicalize(),
         ];
+        yield 'rearranged-imports' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/rearranged-imports.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/rearranged-imports.wsdl'),
+            comparable(),
+        ];
     }
 }

--- a/tests/fixtures/flattening/rearranged-imports.wsdl
+++ b/tests/fixtures/flattening/rearranged-imports.wsdl
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<definitions name="InteropTest"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+            <import namespace="http://soapinterop.org/rearranged-import" schemaLocation="xsd/rearranged-import.xsd" />
+            <xsd:include schemaLocation="xsd/rearranged-include1.xsd" />
+            <xsd:include schemaLocation="xsd/rearranged-include2.xsd" />
+
+            <element name="element1" type="xsd:string" />
+        </schema>
+    </types>
+</definitions>

--- a/tests/fixtures/flattening/result/rearranged-imports.wsdl
+++ b/tests/fixtures/flattening/result/rearranged-imports.wsdl
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<definitions name="InteropTest"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+            <import namespace="http://soapinterop.org/rearranged-import" />
+            <import namespace="http://soapinterop.org/rearranged-import1" />
+            <import namespace="http://soapinterop.org/rearranged-import2" />
+
+            <element name="element1" type="xsd:string" />
+            <element name="includedElement1" type="xsd:string" />
+            <element name="includedElement2" type="xsd:string" />
+        </schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import"></schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import1"></schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import2"></schema>
+    </types>
+</definitions>

--- a/tests/fixtures/flattening/xsd/rearranged-import.xsd
+++ b/tests/fixtures/flattening/xsd/rearranged-import.xsd
@@ -1,0 +1,1 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import"></schema>

--- a/tests/fixtures/flattening/xsd/rearranged-import1.xsd
+++ b/tests/fixtures/flattening/xsd/rearranged-import1.xsd
@@ -1,0 +1,1 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import1"></schema>

--- a/tests/fixtures/flattening/xsd/rearranged-import2.xsd
+++ b/tests/fixtures/flattening/xsd/rearranged-import2.xsd
@@ -1,0 +1,1 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/rearranged-import2"></schema>

--- a/tests/fixtures/flattening/xsd/rearranged-include1.xsd
+++ b/tests/fixtures/flattening/xsd/rearranged-include1.xsd
@@ -1,0 +1,6 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+
+    <import namespace="http://soapinterop.org/rearranged-import1" schemaLocation="rearranged-import1.xsd" />
+
+    <element name="includedElement1" type="xsd:string" />
+</schema>

--- a/tests/fixtures/flattening/xsd/rearranged-include2.xsd
+++ b/tests/fixtures/flattening/xsd/rearranged-include2.xsd
@@ -1,0 +1,6 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+
+    <import namespace="http://soapinterop.org/rearranged-import2" schemaLocation="rearranged-import2.xsd" />
+
+    <element name="includedElement2" type="xsd:string" />
+</schema>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/php-soap/wsdl/issues/21

#### Summary

Makes sure to rearrange the import statements on top of the flattened XSD schema.
This makes the flattened XSD spec compliant:

See https://www.w3.org/TR/xmlschema11-1/#declare-schema

```
<schema>
Content: ((include | import | redefine | override | annotation)*,
(defaultOpenContent, annotation*)?,
((simpleType | complexType | group | attributeGroup | element | attribute | notation), annotation*)*)
</schema>
```

