### PR TITLE
Resolve conflicting XMLNS imports

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -27,4 +27,7 @@
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
     </plugins>
+    <stubs>
+        <file name="stubs/dom.phpstub" />
+    </stubs>
 </psalm>

--- a/src/Xml/Configurator/FlattenWsdlImports.php
+++ b/src/Xml/Configurator/FlattenWsdlImports.php
@@ -16,6 +16,7 @@ use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Exception\RuntimeException;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Locator\Node\children;
+use function VeeWee\Xml\Dom\Manipulator\Element\copy_named_xmlns_attributes;
 use function VeeWee\Xml\Dom\Manipulator\Node\append_external_node;
 use function VeeWee\Xml\Dom\Manipulator\Node\remove;
 use function VeeWee\Xml\Dom\Manipulator\Node\replace_by_external_nodes;
@@ -82,6 +83,7 @@ final class FlattenWsdlImports implements Configurator
     private function importWsdlPart(DOMElement $importElement, Document $importedDocument): void
     {
         $definitions = $importedDocument->map(document_element());
+        copy_named_xmlns_attributes($importElement->ownerDocument->documentElement, $definitions);
 
         replace_by_external_nodes(
             $importElement,

--- a/src/Xml/Visitor/ReprefixTypeQname.php
+++ b/src/Xml/Visitor/ReprefixTypeQname.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Wsdl\Xml\Visitor;
+
+use DOMNode;
+use VeeWee\Xml\Dom\Traverser\Action;
+use VeeWee\Xml\Dom\Traverser\Visitor;
+use function VeeWee\Xml\Dom\Predicate\is_attribute;
+
+final class ReprefixTypeQname extends Visitor\AbstractVisitor
+{
+    /**
+     * @param array<string, string> $prefixMap - "From" key - "To" value prefix map
+     */
+    public function __construct(
+        private readonly array $prefixMap
+    ) {
+    }
+
+    public function onNodeEnter(DOMNode $node): Action
+    {
+        if (!is_attribute($node) || $node->localName !== 'type') {
+            return new Action\Noop();
+        }
+
+        $parts = explode(':', $node->nodeValue ?? '', 2);
+        if (count($parts) !== 2) {
+            return new Action\Noop();
+        }
+
+        [$currentPrefix, $currentTypeName] = $parts;
+        if (!array_key_exists($currentPrefix, $this->prefixMap)) {
+            return new Action\Noop();
+        }
+
+        $node->nodeValue = $this->prefixMap[$currentPrefix].':'.$currentTypeName;
+
+        return new Action\Noop();
+    }
+}

--- a/src/Xml/Xmlns/FixRemovedDefaultXmlnsDeclarationsDuringImport.php
+++ b/src/Xml/Xmlns/FixRemovedDefaultXmlnsDeclarationsDuringImport.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Wsdl\Xml\Xmlns;
+
+use DOMElement;
+
+/**
+ * @see https://gist.github.com/veewee/32c3aa94adcf878700a9d5baa4b2a2de
+ *
+ * PHP does an optimization of namespaces during `importNode()`.
+ * In some cases, this causes the root xmlns to be removed from the imported node which could lead to xsd qname errors.
+ *
+ * This function tries to re-add the root xmlns if it's available on the source but not on the target.
+ *
+ * It will most likely be solved in PHP 8.4's new spec compliant DOM\XMLDocument implementation.
+ * @see https://github.com/php/php-src/pull/13031
+ *
+ * For now, this will do the trick.
+ */
+final class FixRemovedDefaultXmlnsDeclarationsDuringImport
+{
+    public function __invoke(DOMElement $target, DOMElement $source): void
+    {
+        if (!$source->getAttribute('xmlns') || $target->hasAttribute('xmlns')) {
+            return;
+        }
+
+        $target->setAttribute('xmlns', $source->getAttribute('xmlns'));
+    }
+}

--- a/src/Xml/Xmlns/RegisterNonConflictingXmlnsNamespaces.php
+++ b/src/Xml/Xmlns/RegisterNonConflictingXmlnsNamespaces.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Wsdl\Xml\Xmlns;
+
+use DOMElement;
+use DOMNameSpaceNode;
+use Psl\Option\Option;
+use RuntimeException;
+use Soap\Wsdl\Xml\Visitor\ReprefixTypeQname;
+use VeeWee\Xml\Dom\Collection\NodeList;
+use VeeWee\Xml\Dom\Document;
+use function Psl\Dict\merge;
+use function Psl\Option\none;
+use function Psl\Option\some;
+use function VeeWee\Xml\Dom\Builder\xmlns_attribute;
+use function VeeWee\Xml\Dom\Locator\Xmlns\linked_namespaces;
+
+/**
+ * Cross-import schemas can contain namespace conflicts.
+ *
+ * For example: import1 requires import2:
+ *
+ * - Import 1 specifies xmlns:ns1="urn:1"
+ * - Import 2 specifies xmlns:ns1="urn:2".
+ *
+ * This method will detect conflicting namespaces and resolve them.
+ * Namespaces will be renamed to a unique name and the "type" argument with QName's will be re-prefixed.
+ *
+ * @psalm-type RePrefixMap=array<string, string>
+ */
+final class RegisterNonConflictingXmlnsNamespaces
+{
+    /**
+     * @throws RuntimeException
+     */
+    public function __invoke(DOMElement $existingSchema, DOMElement $newSchema): void
+    {
+        $existingLinkedNamespaces = linked_namespaces($existingSchema);
+
+        $rePrefixMap = linked_namespaces($newSchema)->reduce(
+            /**
+             * @param RePrefixMap $rePrefixMap
+             * @return RePrefixMap
+             */
+            function (array $rePrefixMap, DOMNameSpaceNode $xmlns) use ($existingSchema, $existingLinkedNamespaces): array {
+                // Skip non-named xmlns attributes:
+                if (!$xmlns->prefix) {
+                    return $rePrefixMap;
+                }
+
+                // Check for duplicates:
+                if ($existingSchema->hasAttribute($xmlns->nodeName) && $existingSchema->getAttribute($xmlns->nodeName) !== $xmlns->prefix) {
+                    return merge(
+                        $rePrefixMap,
+                        // Can be improved with orElse when we are using PSL V3.
+                        $this->tryUsingExistingPrefix($existingLinkedNamespaces, $xmlns)
+                            ->unwrapOrElse(
+                                fn () => $this->tryUsingUniquePrefixHash($existingSchema, $xmlns)
+                                    ->unwrapOrElse(
+                                        static fn () => throw new RuntimeException('Could not resolve conflicting namespace declarations whilst flattening your WSDL file.')
+                                    )
+                            )
+                    );
+                }
+
+                xmlns_attribute($xmlns->prefix, $xmlns->namespaceURI)($existingSchema);
+
+                return $rePrefixMap;
+            },
+            []
+        );
+
+        if (count($rePrefixMap)) {
+            Document::fromUnsafeDocument($newSchema->ownerDocument)->traverse(new ReprefixTypeQname($rePrefixMap));
+        }
+        (new FixRemovedDefaultXmlnsDeclarationsDuringImport())($existingSchema, $newSchema);
+    }
+
+    /**
+     * @param NodeList<DOMNameSpaceNode> $existingLinkedNamespaces
+     *
+     * @return Option<RePrefixMap>
+     */
+    private function tryUsingExistingPrefix(
+        NodeList $existingLinkedNamespaces,
+        DOMNameSpaceNode $xmlns
+    ): Option {
+        $existingPrefix = $existingLinkedNamespaces->filter(
+            static fn (DOMNameSpaceNode $node) => $node->namespaceURI === $xmlns->namespaceURI
+        )->first()?->prefix;
+
+        if ($existingPrefix === null) {
+            /** @var Option<RePrefixMap> */
+            return none();
+        }
+
+        /** @var Option<RePrefixMap> */
+        return some([$xmlns->prefix => $existingPrefix]);
+    }
+
+    /**
+     * @return Option<RePrefixMap>
+     *
+     * @throws RuntimeException
+     */
+    private function tryUsingUniquePrefixHash(
+        DOMElement $existingSchema,
+        DOMNameSpaceNode $xmlns
+    ): Option {
+        $uniquePrefix = 'ns' . substr(md5($xmlns->namespaceURI), 0, 8);
+        if ($existingSchema->hasAttribute('xmlns:'.$uniquePrefix)) {
+            /** @var Option<RePrefixMap> */
+            return none();
+        }
+
+        $this->copyXmlnsDeclaration($existingSchema, $xmlns->namespaceURI, $uniquePrefix);
+
+        /** @var Option<RePrefixMap> */
+        return some([$xmlns->prefix => $uniquePrefix]);
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function copyXmlnsDeclaration(DOMElement $existingSchema, string $namespaceUri, string $prefix): void
+    {
+        xmlns_attribute($prefix, $namespaceUri)($existingSchema);
+    }
+}

--- a/stubs/dom.phpstub
+++ b/stubs/dom.phpstub
@@ -1,0 +1,7 @@
+<?php
+
+class DOMNameSpaceNode extends DOMNode {
+    public string $namespaceURI;
+    public string $nodeName;
+    public string $prefix;
+}

--- a/tests/Unit/Xml/Configurator/FlattenWsdlImportsTest.php
+++ b/tests/Unit/Xml/Configurator/FlattenWsdlImportsTest.php
@@ -54,5 +54,9 @@ final class FlattenWsdlImportsTest extends TestCase
             'wsdl' => FIXTURE_DIR.'/flattening/import-multi-xsd.wsdl',
             'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/import-multi-xsd-result.wsdl', comparable()),
         ];
+        yield 'import-namespaces' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/import-namespaces.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/import-namespaces.wsdl', comparable()),
+        ];
     }
 }

--- a/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
+++ b/tests/Unit/Xml/Configurator/FlattenXsdImportsTest.php
@@ -76,5 +76,10 @@ final class FlattenXsdImportsTest extends TestCase
             'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/rearranged-imports.wsdl'),
             comparable(),
         ];
+        yield 'import-xmlns-issue' => [
+            'wsdl' => FIXTURE_DIR.'/flattening/conflicting-imports.wsdl',
+            'expected' => Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/conflicting-imports.wsdl'),
+            canonicalize(),
+        ];
     }
 }

--- a/tests/Unit/Xml/Visitor/ReprefixTypeQnameTest.php
+++ b/tests/Unit/Xml/Visitor/ReprefixTypeQnameTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace SoapTest\Wsdl\Unit\Xml\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Soap\Wsdl\Xml\Visitor\ReprefixTypeQname;
+use VeeWee\Xml\Dom\Document;
+
+final class ReprefixTypeQnameTest extends TestCase
+{
+    /**
+     *
+     * @dataProvider provideCases
+     */
+    public function test_it_can_reprefix_qname_types(string $input, string $expected): void
+    {
+        $doc = Document::fromXmlString($input);
+        $doc->traverse(new ReprefixTypeQname([
+            'tns' => 'new',
+            'new' => 'previous', // To make sure prefix replacements don't get chained
+        ]));
+
+        static::assertXmlStringEqualsXmlString($expected, $doc->toXmlString());
+    }
+
+    public static function provideCases(): iterable
+    {
+        yield 'no-attr' => [
+            '<element />',
+            '<element />',
+        ];
+        yield 'other-attribute' => [
+            '<element other="xsd:Type" />',
+            '<element other="xsd:Type" />',
+        ];
+        yield 'no-qualified' => [
+            '<element type="Type" />',
+            '<element type="Type" />',
+        ];
+        yield 'simple' => [
+            '<node type="tns:Type" />',
+            '<node type="new:Type" />',
+        ];
+        yield 'element' => [
+            '<element type="tns:Type" />',
+            '<element type="new:Type" />',
+        ];
+        yield 'attribute' => [
+            '<attribute type="tns:Type" />',
+            '<attribute type="new:Type" />',
+        ];
+        yield 'nested-schema' => [
+            <<<EOXML
+            <complexType name="Store">
+                <sequence>
+                    <element minOccurs="1" maxOccurs="1" name="phone" type="tns:string"/>
+                </sequence>
+            </complexType>
+            EOXML,
+            <<<EOXML
+            <complexType name="Store">
+                <sequence>
+                    <element minOccurs="1" maxOccurs="1" name="phone" type="new:string"/>
+                </sequence>
+            </complexType>
+            EOXML,
+        ];
+        yield 'dont-chain-reprefixes' => [
+            '<schema><element type="tns:Type" /><element type="new:Type" /></schema>',
+            '<schema><element type="new:Type" /><element type="previous:Type" /></schema>',
+        ];
+    }
+}

--- a/tests/Unit/Xml/Xmlns/RegisterNonConflictingXmlnsNamespacesTest.php
+++ b/tests/Unit/Xml/Xmlns/RegisterNonConflictingXmlnsNamespacesTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace SoapTest\Wsdl\Unit\Xml\Xmlns;
+
+use PHPUnit\Framework\TestCase;
+use Soap\Wsdl\Xml\Xmlns\RegisterNonConflictingXmlnsNamespaces;
+use VeeWee\Xml\Dom\Document;
+
+final class RegisterNonConflictingXmlnsNamespacesTest extends TestCase
+{
+    /**
+     *
+     * @dataProvider provideCases
+     */
+    public function test_it_registers_non_conflicting_namespaces(
+        string $existingSchemaXml,
+        string $importedSchemaXml,
+        string $expectedExistingSchemaXml,
+        string $expectedImportedSchemaXml
+    ): void {
+        $existingSchema = Document::fromXmlString($existingSchemaXml);
+        $importedSchema = Document::fromXmlString($importedSchemaXml);
+
+        (new RegisterNonConflictingXmlnsNamespaces())(
+            $existingSchema->locateDocumentElement(),
+            $importedSchema->locateDocumentElement()
+        );
+
+        static::assertSame($expectedExistingSchemaXml, $existingSchema->stringifyDocumentElement());
+        static::assertSame($expectedImportedSchemaXml, $importedSchema->stringifyDocumentElement());
+    }
+
+    public static function provideCases(): iterable
+    {
+        yield 'no-conflict' => [
+            'existingSchemaXml' => '<schema xmlns:ns1="urn:1"/>',
+            'importedSchemaXml' => '<schema xmlns:ns2="urn:2"><element type="ns2:Type"/></schema>',
+            'expectedExistingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:ns2="urn:2"/>',
+            'expectedImportedSchemaXml' => '<schema xmlns:ns2="urn:2"><element type="ns2:Type"/></schema>',
+        ];
+        yield 'conflict' => [
+            'existingSchemaXml' => '<schema xmlns:ns1="urn:1"/>',
+            'importedSchemaXml' => '<schema xmlns:ns1="urn:2"><element type="ns1:Type"/></schema>',
+            'expectedExistingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:nsbcf50aa8="urn:2"/>',
+            'expectedImportedSchemaXml' => '<schema xmlns:ns1="urn:2"><element type="nsbcf50aa8:Type"/></schema>',
+        ];
+        yield 'conflict-with-existing-alternative' => [
+            'existingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:ns2="urn:2"/>',
+            'importedSchemaXml' => '<schema xmlns:ns1="urn:2"><element type="ns1:Type" /></schema>',
+            'expectedExistingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:ns2="urn:2"/>',
+            'expectedImportedSchemaXml' => '<schema xmlns:ns1="urn:2"><element type="ns2:Type"/></schema>',
+        ];
+        yield 'multiple-conflicts' => [
+            'existingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:ns2="urn:2" xmlns:ns3="urn:3"/>',
+            'importedSchemaXml' => <<<EOXML
+            <schema xmlns:ns1="urn:2" xmlns:ns2="urn:1" xmlns:ns3="urn:4">
+                <element name="element1" type="ns1:Type"/>
+                <element name="element2" type="ns2:Type"/>
+                <element name="element3" type="ns3:Type"/>
+            </schema>
+            EOXML,
+            'expectedExistingSchemaXml' => '<schema xmlns:ns1="urn:1" xmlns:ns2="urn:2" xmlns:ns3="urn:3" xmlns:ns56ce840f="urn:4"/>',
+            'expectedImportedSchemaXml' => <<<EOXML
+            <schema xmlns:ns1="urn:2" xmlns:ns2="urn:1" xmlns:ns3="urn:4">
+                <element name="element1" type="ns2:Type"/>
+                <element name="element2" type="ns1:Type"/>
+                <element name="element3" type="ns56ce840f:Type"/>
+            </schema>
+            EOXML,
+        ];
+    }
+}

--- a/tests/fixtures/flattening/conflicting-imports.wsdl
+++ b/tests/fixtures/flattening/conflicting-imports.wsdl
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<definitions name="InteropTest"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+            <import namespace="http://soapinterop.org/conflicting-import" schemaLocation="xsd/conflicting-import.xsd" />
+        </schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/conflicting-import"
+            xmlns:ns1="urn:ns1"
+            xmlns:ns2="urn:ns2"
+            xmlns:ns3="urn:ns3"
+        >
+        </schema>
+    </types>
+</definitions>

--- a/tests/fixtures/flattening/import-namespaces.wsdl
+++ b/tests/fixtures/flattening/import-namespaces.wsdl
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        targetNamespace="http://soapinterop.org/">
+    <import namespace="http://soapinterop.org/" location="wsdl/import-namespaces.wsdl" />
+</definitions>

--- a/tests/fixtures/flattening/result/conflicting-imports.wsdl
+++ b/tests/fixtures/flattening/result/conflicting-imports.wsdl
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<definitions name="InteropTest"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    targetNamespace="http://soapinterop.org/">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/xsd">
+            <import namespace="http://soapinterop.org/conflicting-import" />
+        </schema>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/conflicting-import"
+            xmlns:ns1="urn:ns1"
+            xmlns:ns2="urn:ns2"
+            xmlns:ns3="urn:ns3"
+            xmlns:ns56194cb1="urn:ns4"
+        >
+            <element name="element1" type="ns2:string" />
+            <element name="element2" type="ns1:string" />
+            <element name="element3" type="ns56194cb1:string" />
+        </schema>
+    </types>
+</definitions>

--- a/tests/fixtures/flattening/result/import-namespaces.wsdl
+++ b/tests/fixtures/flattening/result/import-namespaces.wsdl
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        xmlns:foo="urn:foo"
+        xmlns:bar="urn:bar"
+        targetNamespace="http://soapinterop.org/">
+    <types />
+</definitions>

--- a/tests/fixtures/flattening/wsdl/import-namespaces.wsdl
+++ b/tests/fixtures/flattening/wsdl/import-namespaces.wsdl
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<definitions
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://soapinterop.org/"
+        xmlns:foo="urn:foo"
+        xmlns:bar="urn:bar"
+        targetNamespace="http://soapinterop.org/">
+</definitions>

--- a/tests/fixtures/flattening/xsd/conflicting-import.xsd
+++ b/tests/fixtures/flattening/xsd/conflicting-import.xsd
@@ -1,0 +1,9 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/conflicting-import"
+    xmlns:ns1="urn:ns2"
+    xmlns:ns2="urn:ns1"
+    xmlns:ns3="urn:ns4"
+>
+    <element name="element1" type="ns1:string" />
+    <element name="element2" type="ns2:string" />
+    <element name="element3" type="ns3:string" />
+</schema>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/
| BC Break     | no
| Fixed issues | 

#### Summary
 Cross-import schemas can contain namespace conflicts.

For example: import1 requires import2:
- Import 1 specifies xmlns:ns1="urn:1"
- Import 2 specifies xmlns:ns1="urn:2".

This method will detect conflicting namespaces and resolve them.
Namespaces will be renamed to a unique name and the "type" argument with QName's will be re-prefixed.


/cc @rauanmayemir This should fix the flattening of your sync API ;)  Can you give it a try?