### PR TITLE
Fix XSD includes without targetNamespace

### DIFF
--- a/src/Xml/Exception/FlattenException.php
+++ b/src/Xml/Exception/FlattenException.php
@@ -13,6 +13,11 @@ final class FlattenException extends RuntimeException
         return new self("Parsing Schema: {$elementName} has no 'schemaLocation' attribute");
     }
 
+    public static function invalidIncludeTargetNamespace(string $parentTns, string $currentTns): self
+    {
+        return new self("Parsing Schema: include has an invalid targetNamespace of '$currentTns'. Expected '$parentTns'");
+    }
+
     public static function unableToImportXsd(string $location): self
     {
         $target = $location ? ' from '.$location : '';

--- a/tests/fixtures/flattening/result/tnsless-xsd-result.wsdl
+++ b/tests/fixtures/flattening/result/tnsless-xsd-result.wsdl
@@ -6,12 +6,9 @@
         xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <types>
         <xsd:schema targetNamespace="http://soapinterop.org/store1">
-            
-        </xsd:schema>
-        <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xsd:complexType name="Store">
                 <xsd:sequence>
-                    <element minOccurs="1" maxOccurs="1" name="Attribute1" type="string"/>
+                    <xsd:element minOccurs="1" maxOccurs="1" name="Attribute1" type="xsd:string"/>
                 </xsd:sequence>
             </xsd:complexType>
         </xsd:schema>

--- a/tests/fixtures/flattening/xsd/tnsless.xsd
+++ b/tests/fixtures/flattening/xsd/tnsless.xsd
@@ -1,7 +1,7 @@
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:complexType name="Store">
         <xsd:sequence>
-            <element minOccurs="1" maxOccurs="1" name="Attribute1" type="string"/>
+            <element minOccurs="1" maxOccurs="1" name="Attribute1" type="xsd:string"/>
         </xsd:sequence>
     </xsd:complexType>
 </schema>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

Fixes https://github.com/php-soap/wsdl/issues/26

Included schemas without `targetNamespace` should be included as-if they had the `targetNamespace` of the including parent schema.


