### PR TITLE
Fix league/uri 7.6+ breakage by normalizing WSDL location to absolute

### DIFF
--- a/src/Loader/FlatteningLoader.php
+++ b/src/Loader/FlatteningLoader.php
@@ -37,6 +37,8 @@ final class FlatteningLoader implements WsdlLoader
     /**
      * Ensures the base location used for resolving imports is absolute.
      * Why: league/uri >= 7.6 throws when resolving a relative reference against a non-absolute base.
+     *
+     * @throws UnloadableWsdlException
      */
     private static function normalizeLocation(string $location): string
     {

--- a/src/Loader/FlatteningLoader.php
+++ b/src/Loader/FlatteningLoader.php
@@ -25,11 +25,30 @@ final class FlatteningLoader implements WsdlLoader
      */
     public function __invoke(string $location): string
     {
+        $location = self::normalizeLocation($location);
         $currentDoc = Document::fromXmlString(
             non_empty_string()->assert(($this->loader)($location))
         );
         $context = FlatteningContext::forWsdl($location, $currentDoc, $this->loader);
 
         return (new Flattener())($location, $currentDoc, $context);
+    }
+
+    /**
+     * Ensures the base location used for resolving imports is absolute.
+     * Why: league/uri >= 7.6 throws when resolving a relative reference against a non-absolute base.
+     */
+    private static function normalizeLocation(string $location): string
+    {
+        if (preg_match('#^[a-z][a-z0-9+.\-]*:#i', $location) === 1) {
+            return $location;
+        }
+
+        $absolute = realpath($location);
+        if ($absolute === false) {
+            throw UnloadableWsdlException::fromLocation($location);
+        }
+
+        return $absolute;
     }
 }

--- a/tests/Unit/Loader/FlatteningLoaderTest.php
+++ b/tests/Unit/Loader/FlatteningLoaderTest.php
@@ -5,8 +5,11 @@ namespace Soap\Wsdl\Test\Unit\Loader;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psl\Ref;
+use Soap\Wsdl\Exception\UnloadableWsdlException;
 use Soap\Wsdl\Loader\FlatteningLoader;
 use Soap\Wsdl\Loader\StreamWrapperLoader;
+use Soap\Wsdl\Loader\WsdlLoader;
 use VeeWee\Xml\Dom\Document;
 use function VeeWee\Xml\Dom\Configurator\comparable;
 
@@ -26,6 +29,68 @@ final class FlatteningLoaderTest extends TestCase
         $flattened = Document::fromXmlString($result, comparable());
 
         static::assertSame($expected->toXmlString(), $flattened->toXmlString());
+    }
+
+    public function test_it_resolves_imports_when_given_a_relative_path(): void
+    {
+        $cwd = getcwd();
+        chdir(FIXTURE_DIR.'/flattening');
+        try {
+            $result = ($this->loader)('single-xsd.wsdl');
+        } finally {
+            chdir($cwd);
+        }
+
+        $flattened = Document::fromXmlString($result, comparable());
+        $expected = Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/single-xsd-result.wsdl', comparable());
+
+        static::assertSame($expected->toXmlString(), $flattened->toXmlString());
+    }
+
+    public function test_it_leaves_uri_scheme_locations_untouched(): void
+    {
+        $result = ($this->loader)('file://'.FIXTURE_DIR.'/flattening/single-xsd.wsdl');
+        $flattened = Document::fromXmlString($result, comparable());
+        $expected = Document::fromXmlFile(FIXTURE_DIR.'/flattening/result/single-xsd-result.wsdl', comparable());
+
+        static::assertSame($expected->toXmlString(), $flattened->toXmlString());
+    }
+
+    public function test_it_throws_when_given_a_non_existing_relative_path(): void
+    {
+        $this->expectException(UnloadableWsdlException::class);
+        ($this->loader)('does-not-exist.wsdl');
+    }
+
+    #[DataProvider('provideSchemeLocations')]
+    public function test_it_forwards_uri_scheme_locations_unchanged(string $location): void
+    {
+        /** @var Ref<?string> $captured */
+        $captured = new Ref(null);
+        $capturingLoader = new class ($captured) implements WsdlLoader {
+            public function __construct(private Ref $captured) {}
+            public function __invoke(string $location): string
+            {
+                $this->captured->value = $location;
+                return '<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"/>';
+            }
+        };
+
+        (new FlatteningLoader($capturingLoader))($location);
+
+        static::assertSame($location, $captured->value);
+    }
+
+    public static function provideSchemeLocations(): iterable
+    {
+        yield 'http' => ['http://example.com/service.wsdl'];
+        yield 'https' => ['https://example.com/service.wsdl'];
+        yield 'file' => ['file:///tmp/service.wsdl'];
+        yield 'ftp' => ['ftp://example.com/service.wsdl'];
+        yield 'scheme-with-plus' => ['svn+ssh://example.com/service.wsdl'];
+        yield 'scheme-with-dot' => ['x.y://example.com/service.wsdl'];
+        yield 'scheme-with-dash' => ['x-y://example.com/service.wsdl'];
+        yield 'mixed-case-scheme' => ['HTTP://example.com/service.wsdl'];
     }
 
     public static function provideTestCases()

--- a/tests/Unit/Loader/FlatteningLoaderTest.php
+++ b/tests/Unit/Loader/FlatteningLoaderTest.php
@@ -67,8 +67,10 @@ final class FlatteningLoaderTest extends TestCase
     {
         /** @var Ref<?string> $captured */
         $captured = new Ref(null);
-        $capturingLoader = new class ($captured) implements WsdlLoader {
-            public function __construct(private Ref $captured) {}
+        $capturingLoader = new class($captured) implements WsdlLoader {
+            public function __construct(private Ref $captured)
+            {
+            }
             public function __invoke(string $location): string
             {
                 $this->captured->value = $location;


### PR DESCRIPTION
## Summary
- league/uri >= 7.6 throws when resolving a relative reference against a non-absolute base, which broke `FlatteningLoader` when users passed a relative WSDL path (fixes #29).
- Normalize the incoming `$location` once at the `FlatteningLoader` entry: scheme-bearing URIs (http, https, file, ...) pass through untouched; filesystem paths are resolved via `realpath()`; non-existent filesystem paths throw `UnloadableWsdlException`.
- `IncludePathBuilder` stays as-is — its existing `starts_with($fromFile, '/')` branch now always matches for filesystem inputs.

## Test plan
- [x] `vendor/bin/phpunit` — full suite green (77/77)
- [x] New `FlatteningLoaderTest` cases:
  - relative path + `chdir` resolves correctly
  - `file://` URI is forwarded untouched
  - non-existing relative path throws `UnloadableWsdlException`
  - data-provider validates the scheme regex for `http`, `https`, `file`, `ftp`, `svn+ssh`, `x.y`, `x-y`, and mixed-case via a capturing `WsdlLoader` using `Psl\Ref`