### PR TITLE
FlatteningLoader|Throw UnloadableWsdlException when loader returns empty content

### DIFF
--- a/src/Exception/UnloadableWsdlException.php
+++ b/src/Exception/UnloadableWsdlException.php
@@ -23,4 +23,9 @@ final class UnloadableWsdlException extends RuntimeException
     {
         return new self($e->getMessage(), (int)$e->getCode(), $e);
     }
+
+    public static function noContentAt(string $location): self
+    {
+        return new self('WSDL at location "'.$location.'" returned no content.');
+    }
 }

--- a/src/Loader/FlatteningLoader.php
+++ b/src/Loader/FlatteningLoader.php
@@ -1,15 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Soap\Wsdl\Loader;
 
-use Psl\Type\Exception\AssertException;
 use Soap\Wsdl\Exception\UnloadableWsdlException;
 use Soap\Wsdl\Loader\Context\FlatteningContext;
 use Soap\Wsdl\Xml\Flattener;
 use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Exception\RuntimeException;
-use function Psl\Type\non_empty_string;
 
 final class FlatteningLoader implements WsdlLoader
 {
@@ -21,14 +20,16 @@ final class FlatteningLoader implements WsdlLoader
     /**
      * @throws RuntimeException
      * @throws UnloadableWsdlException
-     * @throws AssertException
      */
     public function __invoke(string $location): string
     {
         $location = self::normalizeLocation($location);
-        $currentDoc = Document::fromXmlString(
-            non_empty_string()->assert(($this->loader)($location))
-        );
+        $content = ($this->loader)($location);
+        if ($content === '') {
+            throw UnloadableWsdlException::noContentAt($location);
+        }
+
+        $currentDoc = Document::fromXmlString($content);
         $context = FlatteningContext::forWsdl($location, $currentDoc, $this->loader);
 
         return (new Flattener())($location, $currentDoc, $context);

--- a/tests/Unit/Loader/FlatteningLoaderTest.php
+++ b/tests/Unit/Loader/FlatteningLoaderTest.php
@@ -22,6 +22,19 @@ final class FlatteningLoaderTest extends TestCase
         $this->loader = new FlatteningLoader(new StreamWrapperLoader());
     }
 
+    public function test_it_throws_when_content_is_empty(): void
+    {
+        $emptyLoader = new class implements WsdlLoader {
+            public function __invoke(string $location): string
+            {
+                return '';
+            }
+        };
+        $this->expectException(UnloadableWsdlException::class);
+
+        (new FlatteningLoader($emptyLoader))('http://example.com/service.wsdl');
+    }
+
     #[DataProvider('provideTestCases')]
     public function test_it_can_load_flattened_imports(string $wsdl, Document $expected): void
     {


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

When a WSDL loader returns empty content, the `FlatteningLoader` would throw an `AssertException` making it hard to understand what went wrong.

This PR replaces it with a  `UnloadableWsdlException` making the error clearer  

#### Changes
- Add `UnloadableWsdlException::noContentAt()` named constructor
- Replace `non_empty_string()->assert()` with an explicit empty check in `FlatteningLoader`
