### PR TITLE
Sync wsdl-tools console version & add release Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  tag            to modify the version and tag"
+
+tag:
+	$(if $(TAG),,$(error TAG is not defined. Pass via "make tag TAG=1.22.0"))
+	@echo Tagging $(TAG)
+	sed -i '' -e "s/APP_VERSION = '.*'/APP_VERSION = '$(TAG)'/" src/Console/AppFactory.php
+	php -l src/Console/AppFactory.php
+	git add -A
+	git commit -m '$(TAG) release' -n
+	git tag -s '$(TAG)' -m 'Version $(TAG)'

--- a/src/Console/AppFactory.php
+++ b/src/Console/AppFactory.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Exception\LogicException;
 
 final class AppFactory
 {
+    private const APP_VERSION = '1.21.0';
+
     /**
      * @psalm-suppress UndefinedClass
      * @var list<class-string>
@@ -21,7 +23,7 @@ final class AppFactory
      */
     public static function create(): Application
     {
-        $app = new Application('wsdl-tools', '1.0.0');
+        $app = new Application('wsdl-tools', self::APP_VERSION);
         $app->addCommands([
             new Command\FlattenCommand(),
             new Command\ValidateCommand(),


### PR DESCRIPTION
## Problem

The `wsdl-tools` console application hardcoded its version (`1.0.0`), which drifted from the released git tags, so `./bin/wsdl` printed a stale version.

## Changes

- Extract the version into a `AppFactory::APP_VERSION` constant set to `1.21.0` (the latest release), so it is both discoverable and rewritable.
- Add a `Makefile` `tag` target (modelled on [phpro/grumphp](https://github.com/phpro/grumphp/blob/v2.x/Makefile)) that rewrites `APP_VERSION`, lints the file, commits and creates a **signed tag without the `v` prefix** — matching the current tag convention — so the constant and the git tag stay in sync by construction:

```sh
make tag TAG=1.22.0
```